### PR TITLE
Remove unnecessary attributes for usergroups.update API

### DIFF
--- a/lib/arisaid/usergroups.rb
+++ b/lib/arisaid/usergroups.rb
@@ -88,6 +88,7 @@ module Arisaid
       group = usergroups.find_by(name: src['name'])
       data = src.dup
       data['usergroup'] = group.id
+      data.delete('users') unless data['users'].nil?
       client.update_usergroup(data)
     end
 


### PR DESCRIPTION
`invalid_array_arg` causes include values that are no longer needed.
https://api.slack.com/methods/usergroups.update
