### PR TITLE
Apply merge notation to users

### DIFF
--- a/lib/arisaid/syncable.rb
+++ b/lib/arisaid/syncable.rb
@@ -20,7 +20,7 @@ module Arisaid
     end
 
     def local
-      local_by_stdin || local_by_file
+      merge_users(local_by_stdin || local_by_file)
     end
 
     def local_by_stdin
@@ -38,6 +38,13 @@ module Arisaid
         raise Arisaid::ConfNotFound.new("Not found: #{local_file_path}")
       end
       YAML.load_file(local_file_path)
+    end
+
+    def merge_users(config)
+      config.map do |c|
+        c["users"] = c["users"].flatten.uniq
+        c
+      end
     end
 
     def initialize(team = nil)

--- a/test/arisaid/syncable_test.rb
+++ b/test/arisaid/syncable_test.rb
@@ -1,0 +1,26 @@
+require 'helper'
+
+class Arisaid_SyncableTest < Minitest::Test
+  def test_local
+    @dummy = Object.new
+    @dummy.extend(Arisaid::Syncable)
+
+    File.write 'object.yml', <<-YML.lstrip
+---
+- name: tokyo
+  description: Tokyo Members
+  handle: tokyo
+  users: &tokyo
+  - foobar1
+  - foobar2
+- name: yo
+  description: Yo Members
+  handle: yo
+  users:
+  - *tokyo
+  - foobar3
+YML
+    assert_equal @dummy.local[1]["users"], %w(foobar1 foobar2 foobar3)
+    File.delete 'object.yml'
+  end
+end


### PR DESCRIPTION
Hi!
You will be able to define it as follows.

```yaml
- name: example1
   description: example1_description
   handle: example1
   users: &example1
     - foo
- name: example2
   description: example2_description
   handle: example2
   users:
     - *example1
     - bar
```
```ruby
puts yaml["example1"]["users"]
=> ["foo"]
puts yaml["example2"]["users"]
=> ["foo", "bar"]
```