### PR TITLE
exec usergroups.users.update when update users

### DIFF
--- a/lib/arisaid/usergroups.rb
+++ b/lib/arisaid/usergroups.rb
@@ -61,7 +61,7 @@ module Arisaid
 
           next if same?(src, dst)
 
-          if changed?(src, dst)
+          if changed?(src, dst) || users_changed?(src, dst)
             puts "update usergroup: #{src['name']}"
           end
 
@@ -111,7 +111,7 @@ module Arisaid
     end
 
     def changed?(src, dst)
-      !same?(src, dst) && (users_changed?(src, dst) || description_changed?(src, dst))
+      !same?(src, dst) && src['users'] == dst['users']
     end
 
     def users_changed?(src, dst)


### PR DESCRIPTION
I fix to execute usergroups.users.update API when usergroups user has updated.
This API had not executed since https://github.com/pepabo/arisaid/pull/11 has merged.