### PR TITLE
Support the latest API schema

### DIFF
--- a/lib/arisaid/userable.rb
+++ b/lib/arisaid/userable.rb
@@ -7,7 +7,7 @@ module Arisaid
     end
 
     def users!
-      @users = client.users.select { |u|
+      @users = client.users[:members].select { |u|
         u.deleted == false && u.is_bot == false && u.is_restricted == false
       }
     end
@@ -17,7 +17,7 @@ module Arisaid
     end
 
     def guests!
-      @guests = client.users.select { |u|
+      @guests = client.users[:members].select { |u|
         u.deleted == false && u.is_bot == false && u.is_restricted == true
       }
     end
@@ -27,7 +27,7 @@ module Arisaid
     end
 
     def bots!
-      @bots = client.users.select { |u|
+      @bots = client.users[:members].select { |u|
         u.deleted == false && u.is_bot == true && u.is_restricted == false
       }
     end


### PR DESCRIPTION
`client.users` returns the hash from the api endpoint of slack. I specified an attribute of `users` response.