### PR TITLE
Modify the usergroups_update method to specify a symbol

### DIFF
--- a/lib/arisaid/usergroups.rb
+++ b/lib/arisaid/usergroups.rb
@@ -156,7 +156,7 @@ module Arisaid
     def update(src)
       group = usergroups.find_by(name: src['name'])
       data = src.dup
-      data['usergroup'] = group.id
+      data[:usergroup] = group.id
       data.delete('users') unless data['users'].nil?
       begin
         client.usergroups_update(data)

--- a/lib/arisaid/usergroups.rb
+++ b/lib/arisaid/usergroups.rb
@@ -70,7 +70,7 @@ module Arisaid
           end
 
           if users_changed?(src, dst)
-            add = src['users'].flatten.compact.sort  - dst['users'].flatten.compact.sort
+            add = src['users'].flatten.compact.sort - dst['users'].flatten.compact.sort
             delete = dst['users'].flatten.compact.sort - src['users'].flatten.compact.sort
             add.each do |u|
               puts "  + user #{u}"
@@ -92,12 +92,12 @@ module Arisaid
         puts "  - #{src['name']}"
         dst = remote.find_by(name: src['name'])
         case
-        when dst.nil? then create src
-        when same?(src, dst) then nil
-        when changed?(src, dst) then update(src)
-        else
-          usergroup = usergroups.find_by(name: src['name'])
-          update_users(usergroup.id, src)
+          when dst.nil? then create src
+          when same?(src, dst) then nil
+          when changed?(src, dst) then update(src)
+          else
+            usergroup = usergroups.find_by(name: src['name'])
+            update_users(usergroup.id, src)
         end
       end if !(enabled && Arisaid.read_only?)
 
@@ -116,9 +116,9 @@ module Arisaid
 
     def same?(src, dst)
       src['name'] == dst['name'] &&
-          src['description'] == dst['description'] &&
-          src['handle'] == dst['handle'] &&
-          src['users'].flatten.compact.sort == dst['users'].flatten.compact.sort
+        src['description'] == dst['description'] &&
+        src['handle'] == dst['handle'] &&
+        src['users'].flatten.compact.sort == dst['users'].flatten.compact.sort
     end
 
     def changed?(src, dst)
@@ -134,7 +134,7 @@ module Arisaid
     end
 
     def create(src)
-      group = client.usergroups_create(src.symbolize_keys.reject {|key| key == :users})
+      group = client.usergroups_create(src.symbolize_keys.reject { |key| key == :users })
       update_users(group.usergroup.id, src) if group.respond_to?(:usergroup)
     rescue => e
       puts "   src: #{src}"
@@ -172,11 +172,12 @@ module Arisaid
         usergroup: group_id,
         users: usernames_to_ids(src['users']).join(',')
       }
-    begin
-      client.usergroups_users_update(data)
-    rescue => e
-      puts "   src: #{data}"
-      raise e
+      begin
+        client.usergroups_users_update(data)
+      rescue => e
+        puts "   src: #{data}"
+        raise e
+      end
     end
 
     def usernames_to_ids(usernames)

--- a/lib/arisaid/usergroups.rb
+++ b/lib/arisaid/usergroups.rb
@@ -32,7 +32,7 @@ module Arisaid
     def apply
       enabled = false
 
-      puts "==== All ===="
+      puts "==== Fetch all setting and enable groups ===="
       local.each do |src|
         puts "  - #{src['name']}"
         dst = remote.find_by(name: src['name'])
@@ -48,7 +48,7 @@ module Arisaid
       remote! if enabled
 
       if Arisaid.read_only?
-        puts "==== Read Only ===="
+        puts "==== Create usergroups ===="
         local.each do |src|
           puts "  - #{src['name']}"
           dst = remote.find_by(name: src['name'])
@@ -87,7 +87,7 @@ module Arisaid
         end
       end
 
-      puts "==== Local ===="
+      puts "==== Update usergroups ===="
       local.each do |src|
         puts "  - #{src['name']}"
         dst = remote.find_by(name: src['name'])
@@ -101,7 +101,7 @@ module Arisaid
         end
       end if !(enabled && Arisaid.read_only?)
 
-      puts "==== Remote ===="
+      puts "==== Disable usergroups ===="
       remote.each do |dst|
         puts "  - #{dst['name']}"
         src = local.find_by(name: dst['name'])

--- a/lib/arisaid/usergroups.rb
+++ b/lib/arisaid/usergroups.rb
@@ -32,7 +32,9 @@ module Arisaid
     def apply
       enabled = false
 
+      puts "==== All ===="
       local.each do |src|
+        puts "  - #{src['name']}"
         dst = remote.find_by(name: src['name'])
         next unless dst.nil?
 
@@ -46,7 +48,9 @@ module Arisaid
       remote! if enabled
 
       if Arisaid.read_only?
+        puts "==== Read Only ===="
         local.each do |src|
+          puts "  - #{src['name']}"
           dst = remote.find_by(name: src['name'])
 
           if dst.nil?
@@ -83,7 +87,9 @@ module Arisaid
         end
       end
 
+      puts "==== Local ===="
       local.each do |src|
+        puts "  - #{src['name']}"
         dst = remote.find_by(name: src['name'])
         case
         when dst.nil? then create src
@@ -95,12 +101,17 @@ module Arisaid
         end
       end if !(enabled && Arisaid.read_only?)
 
+      puts "==== Remote ===="
       remote.each do |dst|
+        puts "  - #{dst['name']}"
         src = local.find_by(name: dst['name'])
         disable dst if src.nil?
       end
 
       nil
+    rescue => e
+      puts "#{e.message}\n  #{e.backtrace&.join("\n  ")}"
+      raise e
     end
 
     def same?(src, dst)
@@ -125,10 +136,16 @@ module Arisaid
     def create(src)
       group = client.usergroups_create(src.symbolize_keys.reject {|key| key == :users})
       update_users(group.usergroup.id, src) if group.respond_to?(:usergroup)
+    rescue => e
+      puts "   src: #{src}"
+      raise e
     end
 
     def enable(group)
       client.usergroups_enable(usergroup: group.id)
+    rescue => e
+      puts "   src: #{group}"
+      raise e
     end
 
     def disable(dst)
@@ -141,7 +158,13 @@ module Arisaid
       data = src.dup
       data['usergroup'] = group.id
       data.delete('users') unless data['users'].nil?
-      client.usergroups_update(data)
+      begin
+        client.usergroups_update(data)
+      rescue => e
+        puts "   src: #{src.inspect}"
+        puts "  data: #{data.inspect}"
+        raise e
+      end
     end
 
     def update_users(group_id, src)
@@ -149,7 +172,11 @@ module Arisaid
         usergroup: group_id,
         users: usernames_to_ids(src['users']).join(',')
       }
+    begin
       client.usergroups_users_update(data)
+    rescue => e
+      puts "   src: #{data}"
+      raise e
     end
 
     def usernames_to_ids(usernames)


### PR DESCRIPTION
Fix the following bugs.

```  
uncaught throw #<ArgumentError: Required arguments :usergroup missing>
  /__w/slack/slack/vendor/bundle/ruby/2.7.0/gems/slack-ruby-client-0.16.0/lib/slack/web/api/endpoints/usergroups.rb:100:in `throw'
  /__w/slack/slack/vendor/bundle/ruby/2.7.0/gems/slack-ruby-client-0.16.0/lib/slack/web/api/endpoints/usergroups.rb:100:in `usergroups_update'
  /__w/slack/slack/vendor/bundle/ruby/2.7.0/bundler/gems/arisaid-9f4bcc4a4c65/lib/arisaid/usergroups.rb:156:in `update'
  /__w/slack/slack/vendor/bundle/ruby/2.7.0/bundler/gems/arisaid-9f4bcc4a4c65/lib/arisaid/usergroups.rb:97:in `block in apply'
  /__w/slack/slack/vendor/bundle/ruby/2.7.0/bundler/gems/arisaid-9f4bcc4a4c65/lib/arisaid/usergroups.rb:91:in `each'
  /__w/slack/slack/vendor/bundle/ruby/2.7.0/bundler/gems/arisaid-9f4bcc4a4c65/lib/arisaid/usergroups.rb:91:in `apply'
  /__w/slack/slack/vendor/bundle/ruby/2.7.0/bundler/gems/arisaid-9f4bcc4a4c65/lib/arisaid/cli.rb:41:in `apply'
  /__w/slack/slack/vendor/bundle/ruby/2.7.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
  /__w/slack/slack/vendor/bundle/ruby/2.7.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
  /__w/slack/slack/vendor/bundle/ruby/2.7.0/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
  /__w/slack/slack/vendor/bundle/ruby/2.7.0/gems/thor-1.2.1/lib/thor/base.rb:485:in `start'
  /__w/slack/slack/vendor/bundle/ruby/2.7.0/bundler/gems/arisaid-9f4bcc4a4c65/exe/arisaid:5:in `<top (required)>'
  bin/arisaid:29:in `load'
  bin/arisaid:29:in `<main>'
```

Specifically, in the following section, the parameter was being given as a string instead of a symbol, which caused an error.
https://github.com/pepabo/arisaid/blob/72d8b3805f66356f93f8bdace49e4896607a42be/lib/arisaid/usergroups.rb#L139-L145

Reference: SlackAPIClient side implementation
[lib/slack/web/api/endpoints/usergroups.rb#L99-L102](https://github.com/slack-ruby/slack-ruby-client/blob/b4c73247d2f1aca7b2037309ca0d82681c576e52/lib/slack/web/api/endpoints/usergroups.rb#L99-L102)

```ruby  
          def usergroups_update(options = {})
            throw ArgumentError.new('Required arguments :usergroup missing') if options[:usergroup].nil?
            post('usergroups.update', options)
          end
```

In addition, a log output has been added to make it easier to follow the error when running on CI.