### PR TITLE
fix "method redefined"

### DIFF
--- a/lib/arisaid/configurable.rb
+++ b/lib/arisaid/configurable.rb
@@ -6,8 +6,6 @@ module Arisaid
     OPTIONS_KEYS = %i(
       debug
       read_only
-      slack_team
-      slack_token
       save_token
       conf_prefix
       exit_status
@@ -62,6 +60,10 @@ module Arisaid
 
     def slack_token
       ENV['SLACK_API_TOKEN'] ||= slack_token!
+    end
+
+    def slack_token=(token)
+      ENV['SLACK_API_TOKEN'] = token
     end
 
     def slack_token!

--- a/lib/arisaid/core_ext/hash.rb
+++ b/lib/arisaid/core_ext/hash.rb
@@ -1,4 +1,6 @@
 class Hash
+  alias_method :original_slice, :slice
+
   def slice(*keys)
     keys.each_with_object(self.class.new) { |k, hash| hash[k] = self[k] if has_key?(k) }
   end

--- a/lib/arisaid/userable.rb
+++ b/lib/arisaid/userable.rb
@@ -1,33 +1,31 @@
 module Arisaid
   module Userable
-    attr_reader :users, :guests, :bots
-
     def users
-      @users ||= users!
+      @_users ||= users!
     end
 
     def users!
-      @users = all_users.select { |u|
+      @_users = all_users.select { |u|
         u.deleted == false && u.is_bot == false && u.is_restricted == false
       }
     end
 
     def guests
-      @guests ||= guests!
+      @_guests ||= guests!
     end
 
     def guests!
-      @guests = all_users.select { |u|
+      @_guests = all_users.select { |u|
         u.deleted == false && u.is_bot == false && u.is_restricted == true
       }
     end
 
     def bots
-      @bots ||= bots!
+      @_bots ||= bots!
     end
 
     def bots!
-      @bots = all_users.select { |u|
+      @_bots = all_users.select { |u|
         u.deleted == false && u.is_bot == true && u.is_restricted == false
       }
     end


### PR DESCRIPTION
I fixed it because the following warning appears when running it with Ruby 3.3.

```
❯ bundle exec rake
/home/kenchan/src/github.com/pepabo/arisaid/lib/arisaid/core_ext/hash.rb:2: warning: method redefined; discarding old slice
/home/kenchan/src/github.com/pepabo/arisaid/lib/arisaid/configurable.rb:50: warning: method redefined; discarding old slack_team
/home/kenchan/src/github.com/pepabo/arisaid/lib/arisaid/configurable.rb:54: warning: method redefined; discarding old slack_team=
/home/kenchan/src/github.com/pepabo/arisaid/lib/arisaid/configurable.rb:63: warning: method redefined; discarding old slack_token
/home/kenchan/src/github.com/pepabo/arisaid/lib/arisaid/userable.rb:5: warning: method redefined; discarding old users
/home/kenchan/src/github.com/pepabo/arisaid/lib/arisaid/userable.rb:15: warning: method redefined; discarding old guests
/home/kenchan/src/github.com/pepabo/arisaid/lib/arisaid/userable.rb:25: warning: method redefined; discarding old bots
Run options: --seed 45432

# Running:

............

Finished in 0.074746s, 160.5428 runs/s, 280.9499 assertions/s.

12 runs, 21 assertions, 0 failures, 0 errors, 0 skips
```
