### PR TITLE
bundle update slack-ruby-client

### DIFF
--- a/arisaid.gemspec
+++ b/arisaid.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "slack-ruby-client", "~> 0.16.0"
+  spec.add_dependency "slack-ruby-client", "~> 2.3"
   spec.add_dependency "thor"
   spec.add_dependency "pit"
   spec.add_dependency "colorize"


### PR DESCRIPTION
I updated it so that it works with the latest slack-ruby-client.
